### PR TITLE
Issue #12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,16 @@
                 <filtering>false</filtering>
             </resource>
 
+            <!-- Allow filtering on plugin.yml and config.yml -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>plugin.yml</include>
+                    <include>config.yml</include>
+                </includes>
+            </resource>
+
             <!-- Add the third-party licenses and notice -->
             <resource>
                 <directory>third-party</directory>

--- a/src/main/java/com/fx/srp/SpeedRunPlus.java
+++ b/src/main/java/com/fx/srp/SpeedRunPlus.java
@@ -42,6 +42,9 @@ public class SpeedRunPlus extends JavaPlugin {
      */
     @Override
     public void onEnable() {
+        // Add the default config file
+        saveDefaultConfig();
+
         // Load 3rd party plugin dependencies
         loadDependencies();
 
@@ -54,7 +57,18 @@ public class SpeedRunPlus extends JavaPlugin {
         // Register event listeners
         registerListeners();
 
-        logger.info("[SRP] The plugin has started successfully!");
+        // Plugin server console banner
+        String version = getDescription().getVersion();
+        String reset = "\u001B[0m";
+        String yellow = "\u001B[33m";
+        logger.info("");
+        logger.info(yellow + "   ____                _____              __ " + reset);
+        logger.info(yellow + "  / __/__  ___ ___ ___/ / _ \\__ _____  __/ /_" + reset);
+        logger.info(yellow + " _\\ \\/ _ \\/ -_) -_) _  / , _/ // / _ \\/_  __/" + reset);
+        logger.info(yellow + "/___/ .__/\\__/\\__/\\_,_/_/|_|\\_,_/_//_/ /_/   " + reset);
+        logger.info(yellow + "   /_/                                       " + reset);
+        logger.info(yellow + "\tby Fx-Costa" + "\t\t" + "v" + version + reset);
+        logger.info("");
     }
 
     /**

--- a/src/main/java/com/fx/srp/config/ConfigHandler.java
+++ b/src/main/java/com/fx/srp/config/ConfigHandler.java
@@ -82,7 +82,8 @@ public final class ConfigHandler {
      * @param seedType     The type of seed to get the weight for.
      */
     public int getSeedWeight(SeedCategory.SeedType seedType) {
-        return seedWeights.get(seedType);
+        if (!filteredSeeds) return 0;
+        return seedWeights.getOrDefault(seedType, 0);
     }
 
     private void loadConfiguration() {
@@ -94,7 +95,6 @@ public final class ConfigHandler {
         loadAFKSettings();
         loadPodiumSettings();
         loadGameRules();
-        logger.info("[SRP] Configuration file loaded!");
     }
 
     private void loadWorldSettings() {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: SRP
-version: 0.0.1
+version: ${project.version}
 author: Fx-Costa
 main: com.fx.srp.SpeedRunPlus
 api-version: 1.16


### PR DESCRIPTION
fix: Save config.yml to plugin folder
fix: Exception when filtered seeds are disabled but weights are still fetched
fix: Correct version output in server console on plugin load

chore: Server console banner on plugin load